### PR TITLE
Use frame information stored in Shared Functional Groups Sequence item

### DIFF
--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -23,8 +23,8 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools
-        pip install -r requirements_test.txt
         pip install .
+        pip install -r requirements_test.txt
     - name: Lint with flake8
       run: flake8 --exclude='bin,build,.eggs'
     - name: Type check with mypy

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,4 +1,4 @@
-mypy==0.961
+mypy==0.971
 pytest==7.1.2
 pytest-cov==3.0.0
 pytest-flake8==1.1.1


### PR DESCRIPTION
When Dimension Organization Type is `TILED_SPARSE`, the optical path identifier and spatial position of frames may be stored in the Shared Functional Groups Sequence if the information is shared across all frames.

So far, `compute_frame_positions()` only looked for the information in Per-Frame Functional Groups Sequence items. This PR fixes the bug, and uses the shared information if available.