### PR TITLE
Update slide.py: Removed bulk_data_uri_handler call

### DIFF
--- a/src/dicomslide/slide.py
+++ b/src/dicomslide/slide.py
@@ -1393,7 +1393,6 @@ def find_slides(
                     series_instance_uid=instance.SeriesInstanceUID,
                     sop_instance_uid=instance.SOPInstanceUID,
                 ),
-                bulk_data_uri_handler=bulk_data_uri_handler
             )
             # Once more, these checks should not be necessary, because we are
             # using these attributes to search for studies in the first place.


### PR DESCRIPTION
Removed bulk_data_uri_handler call, results in wrong URL and ConnectionError: HTTPConnectionPool(host='localhost', port=80): Max retries exceeded